### PR TITLE
Updated <em> tag logic using _

### DIFF
--- a/markdown-tests.lua
+++ b/markdown-tests.lua
@@ -4392,6 +4392,25 @@ This is [an example] [id] reference-style link.
 <p><a href="kbs/wes-box-134.md.lp">Wesel - Boxtel [KBS 134]</a></p>
 ]==]
 
+tests.sven = [[
+TASK_CARGO_DISPATCHER
+~
+<p>TASK_CARGO_DISPATCHER</p>
+~
+TASK _CARGO_ DISPATCHER
+~
+<p>TASK<em>CARGO</em>DISPATCHER</p>
+~
+TASK_CARGO_ DISPATCHER
+~
+<p>TASK_CARGO_ DISPATCHER</p>
+~
+TASK*CARGO*DISPATCHER
+~
+<p>TASK<em>CARGO</em>DISPATCHER</p>
+]]
+
+
 -- Unhandled test: _M*A*S*H_
 
 local quiet_mode

--- a/markdown.lua
+++ b/markdown.lua
@@ -895,9 +895,19 @@ local function emphasis(text)
       text = text:gsub(s .. "([^%s][%*%_]?)" .. s, "<strong>%1</strong>")
       text = text:gsub(s .. "([^%s][^<>]-[^%s][%*%_]?)" .. s, "<strong>%1</strong>")
    end
-   for _, s in ipairs {"%*", "%_"} do
-      text = text:gsub(s .. "([^%s_])" .. s, "<em>%1</em>")
-      text = text:gsub(s .. "(<strong>[^%s_]</strong>)" .. s, "<em>%1</em>")
+   for _, s in ipairs {"%_"} do
+      text = text:gsub("([^%w]+)" .. s .. "([^%s_])" .. s, "%1<em>%2</em> ")
+      text = text:gsub("([^%w]+)" .. s .. "(<strong>[^%s_]</strong>)" ..s, "%1<em>%2</em>")
+      text = text:gsub("([^%w]+)" .. s .. "([^%s_][^<>_]-[^%s_])" .. s, "%1<em>%2</em>")
+      text = text:gsub("([^%w]+)" .. s .. "([^<>_]-<strong>[^<>_]-</strong>[^<>_]-)" .. s, "%1<em>%2</em>")
+      text = text:gsub("^" .. s .. "([^%s_])" .. s, "<em>%1</em> ")
+      text = text:gsub("^" .. s .. "(<strong>[^%s_]</strong>)" ..s, "<em>%1</em>")
+      text = text:gsub("^" .. s .. "([^%s_][^<>_]-[^%s_])" .. s, "<em>%1</em>")
+      text = text:gsub("^" .. s .. "([^<>_]-<strong>[^<>_]-</strong>[^<>_]-)" .. s, "<em>%1</em>")
+   end
+   for _, s in ipairs {"%*"} do
+      text = text:gsub(s .. "([^%s_])" .. s, "<em>%1</em> ")
+      text = text:gsub(s .. "(<strong>[^%s_]</strong>)" ..s, "<em>%1</em>")
       text = text:gsub(s .. "([^%s_][^<>_]-[^%s_])" .. s, "<em>%1</em>")
       text = text:gsub(s .. "([^<>_]-<strong>[^<>_]-</strong>[^<>_]-)" .. s, "<em>%1</em>")
    end


### PR DESCRIPTION
In markdown, an _ is something special ... One cannot just scan for every _ in a text and emphasize every text between _ (underscores). In many program languages, _ are used to represent a space in identifiers and functions etc.

**Therefore, I've updated the markdown.lua logic to ensure that text between _ is only emphasized when the first _ starts with a space or any other non alpameric character, or the _ starts at the beginning of the text.**

examples:

AI\_CARGO\_DISPATCHER gives AI\_CARGO\_DISPATCHER.
AI \_CARGO\_ DISPATCHER gives AI <em>CARGO</em> DISPATCHER.
\_AI\_CARGO\_DISPATCHER gives <em>AI</em>CARGO\_DISPATCHER.

but!

AI\*CARGO\*DISPATCHER would still gives AI<em>CARGO</em>DISPATCHER !

I think this change makes a lot of sense and I hope this can be incorporated in the main master branch.
The way how I coded this may not be the most efficient, but I am sure that you'll understand why I approached the problem like this.

I have added `tests.sven` to the test mix to ensure that the above is properly tested.

One test case in the original test cases now will give an error, and I think you need to review this. The test case itself is I think a lot of bollocks :-) I think this test case can be safely removed from the set, but it is your decision what to do with it :-)

thanks for your advice and I hope this pull request can be accepted!

Sven (FlightControl) Van de Velde
